### PR TITLE
Support base path-prefixed assets and routes

### DIFF
--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -2,6 +2,7 @@ import { siteConfig } from "@/config/site";
 import Link from "next/link";
 import { Playfair_Display } from "next/font/google";
 import Image from "next/image";
+import { prefixPath } from "@/lib/prefixPath";
 
 const playfair = Playfair_Display({ subsets: ["latin"] });
 
@@ -12,10 +13,10 @@ export function Footer() {
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div>
             <Link
-              href="/"
+              href={prefixPath("/")}
               className={`${playfair.className} text-2xl flex items-center gap-2 hover:text-[#C79F7D] transition-colors mb-4`}
             >
-              <Image src="/svg/Logo.svg" alt="Logo" width={100} height={40} />
+              <Image src={prefixPath("/svg/Logo.svg")} alt="Logo" width={100} height={40} />
             </Link>
             <p className="text-[#4A3F35]/80">
               Tu centro de estética avanzada de confianza

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import Image from "next/image"; // Agregar esta importación
 import { siteConfig } from "@/config/site";
+import { prefixPath } from "@/lib/prefixPath";
 import { Playfair_Display } from "next/font/google";
 import { Menu, X } from "lucide-react"; // Quitar Sparkles de aquí
 import { RiInstagramLine, RiFacebookCircleLine, RiWhatsappLine } from "react-icons/ri";
@@ -16,6 +17,14 @@ export function Navbar() {
   const [scrolled, setScrolled] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const pathname = usePathname();
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+  const normalizedBasePath =
+    basePath && basePath.endsWith('/') && basePath !== '/' ? basePath.slice(0, -1) : basePath;
+  const normalizedPathname =
+    normalizedBasePath && pathname.startsWith(normalizedBasePath)
+      ? pathname
+      : `${normalizedBasePath}${pathname}`;
+  const logoSrc = prefixPath("/img/logo-horizontal.png");
 
   useEffect(() => {
     const handleScroll = () => {
@@ -32,12 +41,15 @@ export function Navbar() {
     }`}>
       <div className="max-w-7xl mx-auto px-4 py-4">
         <div className="flex items-center justify-between">
-          <Link href="/" className={`${playfair.className} text-2xl flex items-center gap-2 hover:text-[#C79F7D] transition-colors`}>
-            <Image 
-              src="/img/logo-horizontal.png" 
-              alt="Logo" 
-              width={150} 
-              height={1} 
+          <Link
+            href={prefixPath("/")}
+            className={`${playfair.className} text-2xl flex items-center gap-2 hover:text-[#C79F7D] transition-colors`}
+          >
+            <Image
+              src={logoSrc}
+              alt="Logo"
+              width={150}
+              height={1}
             />
           </Link>
           
@@ -48,7 +60,7 @@ export function Navbar() {
                 key={item.href}
                 href={item.href}
                 className={`nav-link text-sm font-medium ${
-                  pathname === item.href ? 'active' : ''
+                  normalizedPathname === item.href ? 'active' : ''
                 }`}
               >
                 {item.label}
@@ -72,10 +84,12 @@ export function Navbar() {
                 <Icon className="w-6 h-6" />
               </Link>
             ))}
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               className="ml-4 hidden md:flex hover:text-[#C79F7D] transition-colors"
-              onClick={() => window.location.href = "/contacto"}
+              onClick={() => {
+                window.location.href = prefixPath("/contacto");
+              }}
             >
               Reservar Cita
             </Button>
@@ -103,7 +117,7 @@ export function Navbar() {
                   key={item.href}
                   href={item.href}
                   className={`text-lg font-medium ${
-                    pathname === item.href ? 'text-[#C79F7D]' : 'text-[#4A3F35]'
+                    normalizedPathname === item.href ? 'text-[#C79F7D]' : 'text-[#4A3F35]'
                   }`}
                   onClick={() => setMobileMenuOpen(false)}
                 >

--- a/components/sections/featured-products.tsx
+++ b/components/sections/featured-products.tsx
@@ -16,6 +16,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { Playfair_Display } from "next/font/google";
 import { motion } from "framer-motion";
+import { prefixPath } from "@/lib/prefixPath";
 
 const playfair = Playfair_Display({ subsets: ["latin"] });
 
@@ -53,7 +54,7 @@ export function FeaturedProducts() {
             </p>
           </div>
           <Link
-            href="/productos"
+            href={prefixPath("/productos")}
             className="hidden md:flex items-center gap-2 text-[#C79F7D] hover:text-[#B68E6C] transition-colors"
           >
             <span className="font-medium">Ver todos los productos</span>
@@ -98,7 +99,7 @@ export function FeaturedProducts() {
                       {product.description}
                     </p>
                     <div className="flex items-center gap-8">
-                      <Link href={`/contacto`}>
+                      <Link href={prefixPath("/contacto")}>
                         <Button className="bg-[#C79F7D] hover:bg-[#B68E6C] text-white px-8 py-6 text-lg">
                           <ShoppingBag className="w-5 h-5 mr-2" />
                           Consultar precio
@@ -130,7 +131,7 @@ export function FeaturedProducts() {
         </div>
 
         <Link
-          href="/productos"
+          href={prefixPath("/productos")}
           className="mt-8 flex md:hidden items-center justify-center gap-2 text-[#C79F7D] hover:text-[#B68E6C] transition-colors"
         >
           <span className="font-medium">Ver todos los productos</span>

--- a/components/sections/featured-services.tsx
+++ b/components/sections/featured-services.tsx
@@ -4,6 +4,7 @@ import { siteConfig } from "@/config/site";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { ArrowRight } from "lucide-react";
+import { prefixPath } from "@/lib/prefixPath";
 
 export function FeaturedServices() {
   return (
@@ -49,7 +50,7 @@ export function FeaturedServices() {
                   {service.description}
                 </p>
                 <Link
-                  href="/contacto"
+                  href={prefixPath("/contacto")}
                   className="inline-flex items-center gap-2 text-[#C79F7D] font-medium hover:text-[#B68E6C] transition-colors group"
                 >
                   <span>Consultar precio</span>

--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -6,6 +6,7 @@ import { Playfair_Display } from "next/font/google";
 import Link from 'next/link';
 import { motion } from "framer-motion";
 import { WhyUs } from "./why-us";
+import { prefixPath } from "@/lib/prefixPath";
 
 const playfair = Playfair_Display({ subsets: ["latin"] });
 
@@ -79,7 +80,7 @@ export function Hero() {
                     Glow estética avanzada
                   </h1>
                   <div className="flex flex-col sm:flex-row gap-4">
-                    <Link href="/equipo">
+                    <Link href={prefixPath("/equipo")}>
                       <Button
                         size="lg"
                         className="hidden md:inline-flex w-full sm:w-auto bg-white text-black hover:bg-white/90 text-lg px-8 py-6"
@@ -87,7 +88,7 @@ export function Hero() {
                         Conoce nuestro equipo
                       </Button>
                     </Link>
-                    <Link href="/contacto">
+                    <Link href={prefixPath("/contacto")}>
                       <Button
                         variant="outline"
                         size="lg"

--- a/components/sections/services.tsx
+++ b/components/sections/services.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 import { motion } from "framer-motion";
 import { siteConfig } from "@/config/site";
+import { prefixPath } from "@/lib/prefixPath";
 
 export function Services() {
   return (
@@ -20,7 +21,10 @@ export function Services() {
               Descubre nuestros tratamientos más exclusivos para cuidar tu belleza
             </p>
           </div>
-          <Link href="/servicios" className="hidden md:flex items-center gap-2 text-[#C79F7D] hover:text-[#B68E6C] transition-colors">
+          <Link
+            href={prefixPath("/servicios")}
+            className="hidden md:flex items-center gap-2 text-[#C79F7D] hover:text-[#B68E6C] transition-colors"
+          >
             <span className="font-medium">Ver todos los servicios</span>
             <ArrowRight className="w-5 h-5" />
           </Link>
@@ -47,7 +51,10 @@ export function Services() {
                   <h3 className="text-xl font-semibold mb-2 text-[#4A3F35]">{service.title}</h3>
                   <p className="text-[#4A3F35]/80 mb-4">{service.description}</p>
                   <div className="flex items-center justify-between">
-                    <Link href="/contacto" className="text-[#C79F7D] font-medium hover:text-[#B68E6C] transition-colors">
+                    <Link
+                      href={prefixPath("/contacto")}
+                      className="text-[#C79F7D] font-medium hover:text-[#B68E6C] transition-colors"
+                    >
                       Consultar precio
                     </Link>
                     <Button className="bg-[#C79F7D] hover:bg-[#B68E6C] text-white">
@@ -60,8 +67,8 @@ export function Services() {
           ))}
         </div>
 
-        <Link 
-          href="/servicios" 
+        <Link
+          href={prefixPath("/servicios")}
           className="mt-8 flex md:hidden items-center justify-center gap-2 text-[#C79F7D] hover:text-[#B68E6C] transition-colors"
         >
           <span className="font-medium">Ver todos los servicios</span>

--- a/components/services/service-grid.tsx
+++ b/components/services/service-grid.tsx
@@ -5,6 +5,7 @@ import { Calendar } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import type { Service } from "@/types/service";
+import { prefixPath } from "@/lib/prefixPath";
 
 interface ServiceGridProps {
   services: Service[];
@@ -45,7 +46,7 @@ export function ServiceGrid({ services }: ServiceGridProps) {
                   <span className="text-xl font-medium text-[#C79F7D]">
                     {service.price}
                   </span>
-                  <Link href="/contacto">
+                  <Link href={prefixPath("/contacto")}>
                     <Button className="bg-[#C79F7D] hover:bg-[#B68E6C] text-white">
                       Reservar ahora
                     </Button>

--- a/config/home.ts
+++ b/config/home.ts
@@ -8,17 +8,18 @@ import {
   MessageCircle,
 } from "lucide-react";
 import type { HeroSection, WhyUsReason, InstagramPost } from "@/types/home";
+import { prefixPath } from "@/lib/prefixPath";
 
 export const heroSection: HeroSection = {
   title: "Glow estética avanzada",
   buttons: {
     primary: {
       text: "Conoce nuestro equipo",
-      href: "/equipo",
+      href: prefixPath("/equipo"),
     },
     secondary: {
       text: "Contáctanos",
-      href: "/contacto",
+      href: prefixPath("/contacto"),
     },
   },
   categories: [
@@ -84,23 +85,23 @@ export const whyUsReasons: WhyUsReason[] = [
 
 export const instagramPosts: InstagramPost[] = [
   {
-    img: "/img/team/rosa.png",
+    img: prefixPath("/img/team/rosa.png"),
     caption:
       "✨¡Tú eres nuestra prioridad! ✨ Queremos sacar a relucir tu mejor versión y ofrecerte una experiencia única y personalizada.",
     link: "https://www.instagram.com/p/CV1a5k8F3g/",
   },
   {
-    img: "/img/post3.png",
+    img: prefixPath("/img/post3.png"),
     caption: "Antes y después. Resultados en menos de 3 meses 🌟 #GlowUp",
     link: "https://www.instagram.com/reel/C1HMbhALMrg/?utm_source=ig_web_copy_link&igsh=MXVlbnA5YXM1OXYxNw==",
   },
   {
-    img: "/img/post4.png",
+    img: prefixPath("/img/post4.png"),
     caption: "Centro especializado en plasma pen ✨ #Transformation",
     link: "https://www.instagram.com/p/DKzXqoltcrc/?utm_source=ig_web_copy_link&igsh=MTg3eG4zMHN6MG9mZQ==",
   },
   {
-    img: "/img/post5.png",
+    img: prefixPath("/img/post5.png"),
     caption:
       "¡El verano está llegando! Tiempo de sol, playa y momentos al aire libre. Pero recuerda,también aumenta la exposición de tu piel. Este es el momento perfecto para prepararla, fortalecerla y protegerla. La mejor opción es nuestra mesoterapia, un tratamiento que consiste en aplicar pequeñas dosis de vitaminas, minerales y otros ingredientes activos directamente en la piel.",
     link: "https://www.instagram.com/p/DKNO8Pst3d0/?utm_source=ig_web_copy_link&igsh=Nmx3bncxdmhscWts",

--- a/config/products.ts
+++ b/config/products.ts
@@ -1,4 +1,5 @@
 import type { ProductBrand } from "@/types/product";
+import { prefixPath } from "@/lib/prefixPath";
 
 export const productBrands: Record<string, ProductBrand> = {
   toskani: {
@@ -46,8 +47,7 @@ export const productBrands: Record<string, ProductBrand> = {
       {
         name: "GOLDEN AGE",
         description: "Tratamiento no invasivo para rejuvenecimiento facial, mejora de arrugas y flacidez mediante plasma.",
-        image:
-          "/img/services/plasma-pen.png",
+        image: prefixPath("/img/services/plasma-pen.png"),
       },
       {
         name: "SENSATIONS",
@@ -90,14 +90,12 @@ export const productBrands: Record<string, ProductBrand> = {
         name: "RETINOL PRO AGE",
         description:
           "Crema fluida de noche de acción transformadora y antiedad global con retinol puro en una concentración del 0,15% o el 0,3%. Reduce visiblemente los signos de la edad y el fotoenvejecimiento y consigue una renovación total de tu piel.",
-        image:
-          "/img/products/retinol-pro-age.jpg",
+        image: prefixPath("/img/products/retinol-pro-age.jpg"),
       },
       {
         name: "INFINITY EYE SERUM",
         description: "Sérum efecto botox para el contorno de ojos. INFINITY Eye serum es el cuidado diario para el contorno de ojos que activa la regeneración celular de la piel y potencia sus defensas, para retrasar y revertir las causas del envejecimiento.",
-        image:
-          "/img/products/eye-serum.jpg",
+        image: prefixPath("/img/products/eye-serum.jpg"),
       },
       {
         name: "BODY SCULPTOR",

--- a/config/site.ts
+++ b/config/site.ts
@@ -1,20 +1,22 @@
+import { prefixPath } from "@/lib/prefixPath";
+
 export const siteConfig = {
   name: "Glow",
   description:
     "Centro de estética avanzada especializado en tratamientos faciales y corporales",
   mainNav: [
-    { label: "Inicio", href: "/" },
-    { label: "Servicios", href: "/servicios" },
-    { label: "Productos", href: "/productos" },
-    { label: "Nuestro Equipo", href: "/equipo" },
-    { label: "Contacto", href: "/contacto" },
+    { label: "Inicio", href: prefixPath("/") },
+    { label: "Servicios", href: prefixPath("/servicios") },
+    { label: "Productos", href: prefixPath("/productos") },
+    { label: "Nuestro Equipo", href: prefixPath("/equipo") },
+    { label: "Contacto", href: prefixPath("/contacto") },
   ],
   featuredServices: [
     {
       title: "Plasma Pen",
       description:
         "Tratamiento no invasivo para rejuvenecimiento facial, mejora de arrugas y flacidez mediante plasma.",
-      image: "/img/services/plasma-pen.png",
+      image: prefixPath("/img/services/plasma-pen.png"),
     },
     {
       title: "Criolipólisis",
@@ -59,22 +61,19 @@ export const siteConfig = {
       name: "Golden Age",
       description:
         "Crema nutritiva de textura ligera formulada a base de exosomas, vitamina B12 y colágeno biomimético para aportar el cuidado global que tu piel necesita y devolverle la juventud redefiniendo los contornos de tu rostro.",
-      image:
-        "/img/products/golden-age2.webp",
+      image: prefixPath("/img/products/golden-age2.webp"),
     },
     {
       name: "Infinity Eye Serum",
       description:
         "Sérum efecto botox para el contorno de ojos. INFINITY Eye serum es el cuidado diario para el contorno de ojos que activa la regeneración celular de la piel y potencia sus defensas, para retrasar y revertir las causas del envejecimiento.",
-      image:
-        "/img/products/eye-serum.jpg",
+      image: prefixPath("/img/products/eye-serum.jpg"),
     },
     {
       name: "Retinol Pro Age",
       description:
         "Crema fluida de noche de acción transformadora y antiedad global con retinol puro en una concentración del 0,15% o el 0,3%. Reduce visiblemente los signos de la edad y el fotoenvejecimiento y consigue una renovación total de tu piel.",
-      image:
-        "/img/products/retinol-pro-age.jpg",
+      image: prefixPath("/img/products/retinol-pro-age.jpg"),
     },
   ],
   socialLinks: [
@@ -109,7 +108,7 @@ export const siteConfig = {
       items: [
         { label: "Sobre Nosotros", href: "#" },
         { label: "Contacto", href: "#" },
-        { label: "Nuestro Equipo", href: "/equipo" },
+        { label: "Nuestro Equipo", href: prefixPath("/equipo") },
         { label: "FAQ", href: "#" },
       ],
     },

--- a/lib/prefixPath.ts
+++ b/lib/prefixPath.ts
@@ -1,0 +1,14 @@
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const normalizedBasePath = basePath.endsWith('/') && basePath !== '/' ? basePath.slice(0, -1) : basePath;
+
+export function prefixPath(path: string): string {
+  if (!path || !path.startsWith('/')) {
+    return path;
+  }
+
+  if (!normalizedBasePath) {
+    return path;
+  }
+
+  return `${normalizedBasePath}${path}`;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,5 @@
+const isProd = process.env.NODE_ENV === 'production';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
@@ -5,6 +7,9 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   images: { unoptimized: true },
+  env: {
+    NEXT_PUBLIC_BASE_PATH: isProd ? '/glow' : '',
+  },
   webpack: (config, { dev, isServer }) => {
     // Disable webpack caching in development to prevent file system issues
     if (dev) {


### PR DESCRIPTION
## Summary
- expose the production base path to the client via NEXT_PUBLIC_BASE_PATH and add a helper to prefix leading slash URLs
- update site configuration data and components to use the helper so local assets and internal links work when served from /glow

## Testing
- npm run export *(fails: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d96165fe7c8331b2484fbd8e2b188c