### PR TITLE
Configure GitHub Pages base path

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
+const isProd = process.env.NODE_ENV === 'production';
+
 const nextConfig = {
   output: 'export',
+  basePath: isProd ? '/glow' : '',
+  assetPrefix: isProd ? '/glow/' : '',
+  trailingSlash: true,
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
## Summary
- configure Next.js to use the /glow base path and asset prefix when building for production
- enable trailingSlash so the static export produces directory-style routes for GitHub Pages

## Testing
- npm run build *(fails: NextFontError while fetching Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d95d17c62c83318065cef8d9e8ec0b