### PR TITLE
Fix static asset paths for GitHub Pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from "next/font/google";
 import { Navbar } from "@/components/layout/navbar";
 import { Footer } from "@/components/layout/footer";
 import { siteConfig } from "@/config/site";
+import { prefixPath } from "@/lib/prefixPath";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -11,7 +12,7 @@ export const metadata: Metadata = {
   title: `${siteConfig.name} - Estética Avanzada`,
   description: siteConfig.description,
   icons: {
-    icon: '/img/fav.png',
+    icon: prefixPath("/img/fav.png"),
   },
 };
 

--- a/public/.nojekyll
+++ b/public/.nojekyll
@@ -1,0 +1,1 @@
+# Instrucción para GitHub Pages: no ejecutar Jekyll


### PR DESCRIPTION
## Summary
- reference the favicon through the base-path aware helper so static exports resolve correctly on GitHub Pages
- add a .nojekyll sentinel so the exported _next assets are served

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d967648fe88331ad60c90becac524c